### PR TITLE
Added logs read permission to signup endpoint

### DIFF
--- a/services/iam/src/routes/general.js
+++ b/services/iam/src/routes/general.js
@@ -72,6 +72,7 @@ const defaultUserPermissions = [
     'tenant.account.update',
     'flows.control',
     'secrets.secret.readRaw',
+    'logs.read'
 ];
 
 router.post('/register', async (req, res, next) => {


### PR DESCRIPTION
**What has changed?**

- Added logs read permission to new users